### PR TITLE
[Issue 2] Support reading properties from the standard uPortal locati…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,6 @@ dependencies {
     compile("org.jasig.portal:uPortal-soffit-renderer:${soffitVersion}")
     compile('org.springframework.boot:spring-boot-starter-cache')
     compile('org.springframework.boot:spring-boot-starter-web')
-    compile("org.jasig.portal:uPortal-spring:${uportalLibsVersion}")
     compile("com.github.ulisesbocchio:jasypt-spring-boot-starter:${jasyptSpringBootVersion}")
     compile("org.aspectj:aspectjweaver:${aspectjVersion}")
 

--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,9 @@ dependencies {
     compile("org.jasig.portal:uPortal-soffit-renderer:${soffitVersion}")
     compile('org.springframework.boot:spring-boot-starter-cache')
     compile('org.springframework.boot:spring-boot-starter-web')
+    compile("org.jasig.portal:uPortal-spring:${uportalLibsVersion}")
+    compile("com.github.ulisesbocchio:jasypt-spring-boot-starter:${jasyptSpringBootVersion}")
+    compile("org.aspectj:aspectjweaver:${aspectjVersion}")
 
     providedRuntime('org.apache.tomcat.embed:tomcat-embed-jasper')
     providedRuntime('org.springframework.boot:spring-boot-starter-tomcat')

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,3 +16,6 @@ ehcacheVersion=2.10.2
 httpclientVersion=4.5.2
 jstlVersion=1.2
 soffitVersion=5.0.0-M4
+uportalLibsVersion=5.0.0-M4
+jasyptSpringBootVersion=1.15
+aspectjVersion=1.8.10

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,6 +16,5 @@ ehcacheVersion=2.10.2
 httpclientVersion=4.5.2
 jstlVersion=1.2
 soffitVersion=5.0.0-M4
-uportalLibsVersion=5.0.0-M4
 jasyptSpringBootVersion=1.15
 aspectjVersion=1.8.10

--- a/src/main/java/org/apereo/portal/soffits/SoffitSamplesApplication.java
+++ b/src/main/java/org/apereo/portal/soffits/SoffitSamplesApplication.java
@@ -19,19 +19,34 @@
 
 package org.apereo.portal.soffits;
 
+import com.ulisesbocchio.jasyptspringboot.annotation.EnableEncryptableProperties;
 import org.apereo.portal.soffit.renderer.SoffitApplication;
 import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
+import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.cache.ehcache.EhCacheCacheManager;
 import org.springframework.cache.ehcache.EhCacheManagerFactoryBean;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.context.annotation.PropertySources;
 import org.springframework.core.io.ClassPathResource;
 
 @SpringBootApplication
 @SoffitApplication
+@EnableAutoConfiguration(exclude = {
+        DataSourceAutoConfiguration.class,
+        HibernateJpaAutoConfiguration.class
+})
 @EnableCaching
+@EnableEncryptableProperties
+@PropertySources({
+        @PropertySource(value = "file://${portal.home}/global.properties", ignoreResourceNotFound = true),
+        @PropertySource(value = "file://${portal.home}/soffit-samples.properties", ignoreResourceNotFound = true)
+})
 public class SoffitSamplesApplication {
 
     public static void main(String[] args) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -46,4 +46,4 @@ catalina.home=build
 #instagram.api.access_token=
 
 jasypt.encryptor.password=${UP_JASYPT_KEY}
-portal.home=${PORTAL_HOME:${catalina.home}/portal}
+portal.home=${PORTAL_HOME:${catalina.base}/portal}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -44,3 +44,6 @@ catalina.home=build
 # (See:  http://instagram.pixelunion.net/)
 #
 #instagram.api.access_token=
+
+jasypt.encryptor.password=${UP_JASYPT_KEY}
+portal.home=${PORTAL_HOME:${catalina.home}/portal}

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -29,19 +29,19 @@
 <configuration scan="true" scanPeriod="30 seconds">
   <contextName>soffit-samples</contextName>
 
-  <!-- 
-   | Propagate log levels to java.util.logging 
+  <!--
+   | Propagate log levels to java.util.logging
    +-->
   <contextListener class="ch.qos.logback.classic.jul.LevelChangePropagator">
     <resetJUL>true</resetJUL>
   </contextListener>
 
-  <!-- 
-   | Expose the logback configuration via JMX 
+  <!--
+   | Expose the logback configuration via JMX
    +-->
   <jmxConfigurator />
 
-  <!-- 
+  <!--
    | Specify a local property that sets up the logging directory (to tomcat's logs directory).
    +-->
   <property resource="application.properties" />
@@ -49,18 +49,18 @@
 
   <!--
    | Setup a file based logger that rolls
-   | 
+   |
    | http://logback.qos.ch/manual/appenders.html#RollingFileAppender
    +-->
   <appender name="LOG" class="ch.qos.logback.core.rolling.RollingFileAppender">
-    <!-- 
+    <!--
      | Name of the current log file
      +-->
     <File>${LOG_DIR}/${CONTEXT_NAME}.log</File>
 
-    <!-- 
+    <!--
      | Log message pattern configuration
-     | 
+     |
      | http://logback.qos.ch/manual/layouts.html#conversionWord
      +-->
     <encoder>
@@ -71,7 +71,7 @@
      | Rolls the log file every 24 hours
      | gzip the archived log file
      | Delete archived log files older than 28 days
-     | 
+     |
      | http://logback.qos.ch/manual/appenders.html#TimeBasedRollingPolicy
      +-->
     <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
@@ -80,14 +80,14 @@
     </rollingPolicy>
   </appender>
 
-  <!-- 
+  <!--
    | Setup default log level to INFO
    +-->
   <root level="WARN">
     <appender-ref ref="LOG" />
   </root>
 
-  <!-- 
+  <!--
    | Turn up logging for specific packages
    +-->
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
Update to read property files from the standard uPortal locations.


<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl