### PR TITLE
Setup Travis continuous integration for Linux and MacOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: java
+
+matrix:
+  include:
+    - os: linux
+      dist: trusty
+      jdk: oraclejdk8
+    - os: osx
+      osx_image: xcode8.3
+
+install: true
+script: ./gradlew -u -i -S assemble
+
+cache:
+  directories:
+    - $HOME/.gradle/

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# Soffit Samples
+
+[![Build Status](https://travis-ci.org/uPortal-Project/soffit-samples.svg?branch=master)](https://travis-ci.org/uPortal-Project/soffit-samples)
+
 This project contains several example Soffits for uPortal.  More information
 about Soffit can be found on the [Soffit project page](https://github.com/drewwills/Soffit).
 
@@ -23,4 +27,3 @@ on your machine or use the included [Gradle Wrapper](https://docs.gradle.org/cur
 ```bash
   $java -jar build/libs/soffit-samples-0.0.1-SNAPSHOT.war
 ```
-


### PR DESCRIPTION
:notebook: Would require Travis CI be enabled for this project at <https://travis-ci.org/profile/uPortal-Project>.

Travis CI will run a standard build (`./gradlew assemble`) for every commit and pull request, then report status of build back to GitHub. :white_check_mark: :no_entry: 

:building_construction: Example build: https://travis-ci.org/ChristianMurphy/soffit-samples/builds/270527956