### PR TITLE
Setup AppVeyor continuous integration for Windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,10 @@
+environment:
+  JAVA_HOME: C:\Program Files\Java\jdk1.8.0
+os: Visual Studio 2017 # Windows Server 2016
+install:
+  - java -version
+  - gradlew.bat --version
+build: off
+test_script: gradlew.bat -u -i -S assemble
+cache:
+  - C:\Users\appveyor\.gradle


### PR DESCRIPTION
:notebook: Would require AppVeyor to be enabled for this project at <https://ci.appveyor.com/projects/new>

:notebook: AppVeyor does not have a cannonical badge url, whoever enables AppVeyor would need to go to `settings > badges` to get the markdown snippet.

AppVeyor will run a standard build (`./gradlew assemble`) for every commit and pull request, then report status of build back to GitHub. :white_check_mark: :no_entry: 

:building_construction: Example build: https://ci.appveyor.com/project/ChristianMurphy/soffit-samples/build/1.0.1